### PR TITLE
Fix typo in settings page

### DIFF
--- a/Serviceproxmox/html_admin/mod_serviceproxmox_config.phtml
+++ b/Serviceproxmox/html_admin/mod_serviceproxmox_config.phtml
@@ -74,7 +74,7 @@
                     </div>
 					
 					<div class="rowElem noborder">
-                        <label>{% trans 'RAM memory (in GB)' %}:</label>
+                        <label>{% trans 'RAM memory (in MB)' %}:</label>
                         <div class="formRight">
                             <input type="text" name="memory" value="{{ product.config.memory }}" required="required" placeholder="{% trans '1024' %}">
                         </div>


### PR DESCRIPTION
The settings page have an error in text that displays "GB" instead of the correct "MB".